### PR TITLE
Allowed client id and client secret to be null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -487,3 +487,6 @@
 - Added login and refresh methods that uses https://auth.mangadex.org instead of the deprecated login methods.
 - login and refresh methods now return a Token class instance rather than a Login class instance.
 - Removed Login class.
+
+## 2.0.6
+- Allowed client id and client secret to be null while initializing PersonalMangadexClient, this allows for anonymous searching and other functions that don't require a logged in user's auth token

--- a/lib/src/client_types/personal_client.dart
+++ b/lib/src/client_types/personal_client.dart
@@ -7,11 +7,11 @@ import 'package:mangadex_library/src/repositories/auth_repository.dart';
 /// This class requires you to enter a client ID and a client Secret, both can be generated from your
 /// mangadex account. The class extends [MangadexClient] which is the base building class for all clients.
 class MangadexPersonalClient extends MangadexClient {
-  late String _clientId;
-  late String _clientSecret;
+  late String? _clientId;
+  late String? _clientSecret;
   MangadexPersonalClient(
-      {required String clientId,
-      required String clientSecret,
+      {String? clientId,
+      String? clientSecret,
 
       /// whether to automatically refresh the user tokens or not
       bool autoRefresh = true,
@@ -28,33 +28,46 @@ class MangadexPersonalClient extends MangadexClient {
             refreshDuration: refreshDuration) {
     _clientId = clientId;
     _clientSecret = clientSecret;
-    super.setTimer(
-        Timer.periodic(refreshDuration ?? Duration(minutes: 14), (timer) async {
-      if (super.tokenIsNotNull()) {
-        try {
-          super.setToken(
-            await AuthRepository.refreshForPersonalClient(
-                super.token!.refreshToken, clientId, clientSecret),
-          );
-          if (onRefresh != null) {
-            onRefresh();
+    if (_clientId != null && _clientSecret != null) {
+      super.setTimer(Timer.periodic(refreshDuration ?? Duration(minutes: 14),
+          (timer) async {
+        if (super.tokenIsNotNull()) {
+          try {
+            super.setToken(
+              await AuthRepository.refreshForPersonalClient(
+                  super.token!.refreshToken, _clientId!, _clientSecret!),
+            );
+            if (onRefresh != null) {
+              onRefresh();
+            }
+          } on Exception {
+            super.setToken(null);
+            rethrow;
           }
-        } on Exception {
-          super.setToken(null);
-          rethrow;
         }
-      }
-    }));
+      }));
+    } else {
+      super.setToken(null);
+    }
   }
 
+  void setClientID(String? clientId) => _clientId = clientId;
+  void setClientSecret(String? clientSecret) => _clientId = clientSecret;
+
   Future<void> login(String username, String password) async {
+    if (_clientId == null || _clientSecret == null) {
+      throw Exception('ClientId or ClientSecret was not set');
+    }
     final authResponse = await AuthRepository.loginPersonalClient(
-        username, password, _clientId, _clientSecret);
+        username, password, _clientId!, _clientSecret!);
     super.setToken(authResponse);
   }
 
   Future<void> refresh(String refreshToken) async {
+    if (_clientId == null || _clientSecret == null) {
+      throw Exception('ClientId or ClientSecret was not set');
+    }
     super.setToken(await AuthRepository.refreshForPersonalClient(
-        refreshToken, _clientId, _clientSecret));
+        refreshToken, _clientId!, _clientSecret!));
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mangadex_library
 description: A mangadex library for dart to facilitate easier access to the Mangadex API (https://api.mangadex.org)
-version: 2.0.5
+version: 2.0.6
 repository: https://github.com/Riktam-Santra/mangadex_library
 
 environment:

--- a/test/mangadex_library_test.dart
+++ b/test/mangadex_library_test.dart
@@ -50,6 +50,8 @@ void main() async {
     expect('ok', data.result!);
   });
   group('Search Function', () {
+    // new client created for anonymous function check
+    MangadexPersonalClient client = MangadexPersonalClient();
     var query = 'oregairu';
     test('Search function check with only query', () async {
       print('searching for manga with query value: $query');


### PR DESCRIPTION
Allowed client id and client secret to be null while initializing PersonalMangadexClient, this allows for anonymous searching and other functions that don't require a logged in user's auth token